### PR TITLE
修复了pop3.php中getMail()函数的一个bug

### DIFF
--- a/src/Pop3/pop3.php
+++ b/src/Pop3/pop3.php
@@ -257,6 +257,10 @@ class Pop3
         {
             $this->getresp();
             $is_head=true;
+
+	  //清除上次读入的数据
+	  $this->head = [];
+	  $this->body = [];
             while ($this->resp!=".") // . 号是邮件结束的标识
             {
                 if ($this->debug)

--- a/src/Pop3/pop3.php
+++ b/src/Pop3/pop3.php
@@ -255,12 +255,14 @@ class Pop3
             return false;
         else
         {
-            $this->getresp();
-            $is_head=true;
 
 	  //清除上次读入的数据
 	  $this->head = [];
 	  $this->body = [];
+
+            $this->getresp();
+            $is_head=true;
+
             while ($this->resp!=".") // . 号是邮件结束的标识
             {
                 if ($this->debug)


### PR DESCRIPTION
在 原分支 pop3.php 文件的 258 - 274行
```php
            $this->getresp();
            $is_head=true;
            while ($this->resp!=".") // . 号是邮件结束的标识
            {
                if ($this->debug)
                    $this->outdebug($this->resp);
                if (substr($this->resp,0,1)==".")
                    $this->resp=substr($this->resp,1,strlen($this->resp)-1);
                if (trim($this->resp)=="") // 邮件头与正文部分的是一个空行
                    $is_head=false;
                if ($is_head)
                    $this->head[]=$this->resp;
                else
                    $this->body[]=$this->resp;
                $this->getresp();
            }
            return true;
```
第269行与第271行的语句
```php
$this->head[]=$this->resp;
```
```php
$this->body[]=$this->resp;
```
每次拿到响应后，会分别 将响应数据 追加到 自身的属性head和body中。
但是 **未在while循环开始之前** 将 head和body清空，

如果循环读入邮件：
即多次调用getMail()，比如我从得知服务器上有3个邮件，我分别调用getMail(1)、getMail(2)，getMain(3) ），

上一次读入的邮件内容依然会保留在下一次读入的邮件内容中，造成body属性像滚雪球一样越滚越大。
（感谢作者提供这么好的整合包，我也是在使用过程中发现了这个问题，希望作者能给出意见）